### PR TITLE
Add get_tensor_network_state method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 .idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.vscode/launch.json

--- a/src/tnsu/examples.py
+++ b/src/tnsu/examples.py
@@ -140,11 +140,12 @@ def afh_peps_ground_state_experiment(size: int = 4, bc: str = 'obc', d_max_: lis
             plot_convergence_curve(afh_tn_su)
 
         # save the tensor network
+        final_network = afh_tn.get_tensor_network_state()
         if save_network:
-            afh_tn.save_network()
+            final_network.save_network()
 
         # add to networks list
-        networks.append(afh_tn)
+        networks.append(final_network)
 
     return networks, energies
 

--- a/src/tnsu/examples.py
+++ b/src/tnsu/examples.py
@@ -1,6 +1,6 @@
 import numpy as np
 from tnsu.utils import plot_convergence_curve
-from tnsu.tensor_network import TensorNetwork
+from tnsu.tensor_network import TensorNetwork, DEFAULT_NETWORKS_FOLDER
 import tnsu.simple_update as su
 import tnsu.structure_matrix_constructor as smg
 import tnsu.math_objects as mo
@@ -15,7 +15,7 @@ def load_a_tensor_network_from_memory(network_name='AFH_10x10_obc_D_4'):
     net_names = ['AFH_10x10_obc_D_4', 'AFH_20x20_obc_D_4', 'AFH_20x20_pbc_D_4']
     assert network_name in net_names, f'There is no network "{network_name}" in memory. ' \
                                       f'Please choose from:\n {net_names}'
-    dir_path = ''.join([s + '/' for s in __file__.split('/')[:-1]]) + 'networks'
+    dir_path = DEFAULT_NETWORKS_FOLDER
     return load_a_tensor_network_state(network_name, dir_path)
 
 

--- a/src/tnsu/simple_update.py
+++ b/src/tnsu/simple_update.py
@@ -46,9 +46,6 @@ class SimpleUpdate:
         """
 
         # Unpacking the tensor network
-        self.tensors = tensor_network.tensors
-        self.weights = tensor_network.weights
-        self.structure_matrix = tensor_network.structure_matrix
         self.tensor_network = tensor_network
 
         # Simple Update variables
@@ -78,6 +75,19 @@ class SimpleUpdate:
         self.log_energy = log_energy
         self.print_process = print_process
         self.converged = False
+
+    @property
+    def tensors(self) -> list[np.ndarray]:
+        return self.tensor_network.tensors
+
+    @property
+    def weights(self) -> list[np.ndarray]:
+        return self.tensor_network.weights
+    
+    @property
+    def structure_matrix(self) -> list[np.ndarray]:
+        return self.tensor_network.structure_matrix
+
 
     def run(self):
         """
@@ -656,3 +666,11 @@ class SimpleUpdate:
             edges_dims = self.get_edges(tensor_idx=tensor_idx)
             tensor = self.absorb_sqrt_inverse_weights(tensor=tensor, edges_dims=edges_dims)
             self.tensors[tensor_idx] = tensor
+
+    def get_tensor_network_state(self) -> list[np.ndarray]:
+        """
+        Returns a copy of the tensor network with all sqrt(weights) absobed into their 
+        negihboring tensors. This tensor-network is a PEPS represnting the state of the system.
+        :returns: list[np.ndarray]: A list of tensors. The order 
+        """
+        pass

--- a/src/tnsu/tensor_network.py
+++ b/src/tnsu/tensor_network.py
@@ -4,6 +4,9 @@ import os
 import copy as cp
 
 from typing import TypedDict
+import pathlib
+
+DEFAULT_NETWORKS_FOLDER = str(pathlib.Path(__file__).parent/"networks")
 
 class _EdgesDict(TypedDict):
     edges : np.ndarray
@@ -13,7 +16,7 @@ class TensorNetwork:
     """A Tensor-Network object. Used in the field of Quantum Information and Quantum Computation"""
 
     def __init__(self, structure_matrix: np.array = None, tensors: list = None, weights: list = None,
-                 spin_dim: int = 2, virtual_dim: int = 3, dir_path='./networks',
+                 spin_dim: int = 2, virtual_dim: int = 3, dir_path:str|None=None,
                  network_name='tensor_network', random_init_real_loc: float = 1.,
                  random_init_real_scale: float = 1., random_init_imag_loc: float = None,
                  random_init_imag_scale: float = None):
@@ -155,7 +158,7 @@ class TensorNetwork:
         self.tensors = tensors
         self.weights = weights
         self.structure_matrix = structure_matrix
-        self.dir_path = dir_path
+        self.dir_path = dir_path if dir_path is not None else DEFAULT_NETWORKS_FOLDER
         self.network_name = network_name
         self.su_logger = None
         self.state_dict = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,13 @@
+if __name__ == "__main__":
+    import sys, pathlib
+    ## Import src:
+    base_folder = pathlib.Path(__file__).parent.parent
+    src_folder = str(base_folder/"src")
+    if src_folder not in sys.path:
+        sys.path.append(src_folder)
+
+from typing import Generator, Callable
+
 from tnsu.structure_matrix_constructor import infinite_structure_matrix_dict
 import tnsu.simple_update as su
 from tnsu.math_objects import spin_operators as so
@@ -51,3 +61,18 @@ def test_square_lattice():
 
 
 
+def _all_test() -> Generator[Callable[[None], None], None, None]:
+    yield test_load_tensor_network
+    yield test_triangle_lattice
+    yield test_square_lattice
+
+
+if __name__ == "__main__":
+    print("Running all tests:")
+    ## Run all tests:
+    for i, test in enumerate(_all_test()):
+        name = test.__name__
+        print(f"    Test {i}: {name!r}")
+        test()
+    ## No error? All good!
+    print(f"All {i+1} tests passes without errors.")


### PR DESCRIPTION
In response to issue #4:

### Main changes:

- Some attributes of `SimpleUpdate` class are now properties, using the ```@property``` decorator.
- Moved methods that absorb weights into `TensorNetwork` class. This supports the following point.
- Added the method `get_tensor_network_state()` which returns a copy of the `TensorNetwork` object, with weights absorbed into neighboring tensors, to reflect the actual state of the system
- In tnsu/examples.py in `afh_peps_ground_state_experiment()` instead of saving the original TensorNetwork, now the return value of `get_tensor_network_state()` is used
- Some type-hints were added in various places in Both `TensorNetwork` and `SimpleUpdate` classes. Mostly to annotate return values to allow linters to provide coding-hints for users, according to [PEP 484](https://peps.python.org/pep-0484/).

### Possible disagreements or issues:
The return type of `get_tensor_network_state()` is currently a `TensorNetwork` object.
It might make more sense to return a simpler list of tensors (i.e., type `list[np.ndarray]`), where the list is simply `self.tensors`.